### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -166,7 +166,7 @@ gnome-system-tools (2.30.1-2) unstable; urgency=low
 gnome-system-tools (2.30.1-1) unstable; urgency=low
 
   [ Josselin Mouette ]
-  * Bump system-tools-backends runtime dependency to the same version as 
+  * Bump system-tools-backends runtime dependency to the same version as
     the build-time one.
 
   [ Michael Biebl ]
@@ -267,18 +267,18 @@ gnome-system-tools (2.22.2-1) unstable; urgency=low
 
 gnome-system-tools (2.22.1-6) unstable; urgency=low
 
-  * 10_disable_interfaces.patch: new patch. Entirely disable interfaces 
+  * 10_disable_interfaces.patch: new patch. Entirely disable interfaces
     management now that NM has all that’s needed.
   * network-admin.1: modify manual page accordingly.
   * Remove build-dep on libiw accordingly.
   * 90_relibtoolize.patch: relibtoolize on top of that.
-  * 11_dont_show_shares.patch: new patch. Don’t show shares-admin by 
+  * 11_dont_show_shares.patch: new patch. Don’t show shares-admin by
     default in the menu. We want to promote gnome-user-share instead.
   * Stop suggesting samba and wvdial.
   * Remove gnome-network-admin package.
   * gnome-system-tools conflicts/replaces/provides g-n-a.
   * Remove useless debian/dirs.
-  * 61_outdated_docs.patch: disable building of a broken and outdated 
+  * 61_outdated_docs.patch: disable building of a broken and outdated
     document.
   * Disable the nautilus shares extension.
 
@@ -286,14 +286,14 @@ gnome-system-tools (2.22.1-6) unstable; urgency=low
 
 gnome-system-tools (2.22.1-5) unstable; urgency=low
 
-  * Revert 2.22.1-4 change with a brown paper bag, it’s useless since 
+  * Revert 2.22.1-4 change with a brown paper bag, it’s useless since
     policykit depends on consolekit.
-  * 26_users_home_dir.patch: patch from Ubuntu to allow changing root 
+  * 26_users_home_dir.patch: patch from Ubuntu to allow changing root
     propertiew without making /home/root the new home directory.
     Closes: #488252.
-  * gnome-network-admin conflicts with network-manager-gnome. 
+  * gnome-network-admin conflicts with network-manager-gnome.
     Closes: #460691.
-  * 85_users_fix_add_group.patch: patch from Ubuntu to always allow to 
+  * 85_users_fix_add_group.patch: patch from Ubuntu to always allow to
     create groups. Closes: #488249.
 
  -- Josselin Mouette <joss@debian.org>  Tue, 09 Jun 2009 16:43:21 +0200
@@ -317,7 +317,7 @@ gnome-system-tools (2.22.1-3) unstable; urgency=low
 gnome-system-tools (2.22.1-2) unstable; urgency=low
 
   * Upload to unstable.
-  * Downgrade nautilus requirement to build against nautilus 2.20 in 
+  * Downgrade nautilus requirement to build against nautilus 2.20 in
     unstable.
 
  -- Josselin Mouette <joss@debian.org>  Wed, 11 Mar 2009 22:35:57 +0100
@@ -330,10 +330,10 @@ gnome-system-tools (2.22.1-1) experimental; urgency=low
   * 61_network_auto.patch: dropped, merged upstream.
   * Require a system-tools-backends version with PolicyKit support.
   * gnome-network-admin depends on gnome-system-tools = binary:Version.
-  * Build-depend on nautilus 2.22 to build the extension for the new 
+  * Build-depend on nautilus 2.22 to build the extension for the new
     version.
   * Don’t install the .a and .la with the nautilus extension.
-  * 01_wait_for_backends.patch: wait for the connection to the backends 
+  * 01_wait_for_backends.patch: wait for the connection to the backends
     to be established in case they are being autostarted.
 
  -- Josselin Mouette <joss@debian.org>  Sun, 04 Jan 2009 12:01:07 +0100
@@ -346,7 +346,7 @@ gnome-system-tools (2.22.0-3) unstable; urgency=low
       Closes: #488255.
 
   [ Josselin Mouette ]
-  * 61_network_auto.patch: patch from Ubuntu/upstream to add "auto" line 
+  * 61_network_auto.patch: patch from Ubuntu/upstream to add "auto" line
     in /etc/network/interfaces when needed. Closes: #488250.
   * 62_postgresql.patch: add postgresql-8.3 to supported databases.
     Closes: #492355.
@@ -370,7 +370,7 @@ gnome-system-tools (2.22.0-1) unstable; urgency=low
     + Strip the versioned build-dependency on scrollkeeper.
       Closes: #483583.
   * Refresh and update patches to apply cleanly.
-  * 22_root_only.patch: don't switch uid for shares-admin, it does not 
+  * 22_root_only.patch: don't switch uid for shares-admin, it does not
     connect to the session bus.
   * more-groups.patch renamed to 40_more-groups.patch.
 
@@ -647,7 +647,7 @@ gnome-system-tools (0.92.0-1) unstable; urgency=medium
   * New upstream release.
   * Urgency medium as we still have a chance to put this version in Sarge,
     which is interesting for the LSB check fix (below)
-  * debian/patches: 
+  * debian/patches:
      - 05_sarge: modified. check_debian patch now included upstream, adding a
      patch for people going through check_lsb instead.
      - 10_relibtoolize: updated.
@@ -682,10 +682,10 @@ gnome-system-tools (0.90.0-1) unstable; urgency=low
     + 05_sarge: fix detection of Sarge, now that /etc/debiaan_version
       contains 3.1. Patch from Frederic Peters (Closes: #262080)
     + 10_relibtoolize: updated
-      
+
   * debian/control.in
     + removed libvte-dev and libcracklib2-dev Build-Dependency, as they're not
-      needed any longer. 
+      needed any longer.
 
  -- Jose Carlos Garcia Sogo <jsogo@debian.org>  Wed,  4 Aug 2004 16:46:06 +0200
 
@@ -729,7 +729,7 @@ gnome-system-tools (0.31.0-3) unstable; urgency=high
 gnome-system-tools (0.31.0-2) unstable; urgency=low
 
   * Modified src/common/CommonMakefile so those .desktop file are
-  not installed in $(DESTDIR)$(DESTIDR)/$(applications) which caused them 
+  not installed in $(DESTDIR)$(DESTIDR)/$(applications) which caused them
   to be packaged in /home/jose/devel/gst... (Closes: #226377)
 
  -- Jose Carlos Garcia Sogo <jsogo@debian.org>  Tue,  6 Jan 2004 12:43:35 +0100
@@ -867,7 +867,7 @@ ximian-setup-tools (0.11.0-1) unstable; urgency=low
   Control Center >= 1.5 until it is available in Debian.
   * This new version can compile with latest libgal. (Closes: #116465)
   * config-{guess,sub} updated (Closes: #114996)
-  * backends/platform.pl.in: patch applied to correctly detect 
+  * backends/platform.pl.in: patch applied to correctly detect
   Debian 3.0 woody. Thanks to Gergely Nagy.
 
  -- Jose Carlos Garcia Sogo <jsogo@debian.org>  Mon, 17 Dec 2001 23:26:53 +0100
@@ -881,9 +881,9 @@ ximian-setup-tools (0.6.0-4) unstable; urgency=low
 ximian-setup-tools (0.6.0-3) unstable; urgency=low
 
   * Added a missing perl dependency. I had used dh_perl for that, but the perl
-  scripts that the package include use #!/usr/bin/env perl, instead of 
+  scripts that the package include use #!/usr/bin/env perl, instead of
   #!/usr/bin/perl which is the line recognized by dh_perl.
-  
+
   * Linked all the binaries manpage with the undocumented(7) manpage.
   * debian/rules: now support DEB_BUILD_OPTIONS.
 

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Build-Depends: cdbs (>= 0.4.93~),
                gnome-pkg-tools,
                yelp-tools,
                pkg-config
-Standards-Version: 4.5.0
+Standards-Version: 4.6.1
 Homepage: https://github.com/LStranger/gnome-system-tools
 Vcs-Browser: https://github.com/LStranger/gnome-system-tools-debian
 Vcs-Git: https://github.com/LStranger/gnome-system-tools-debian.git

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Build-Depends: cdbs (>= 0.4.93~),
                gnome-pkg-tools,
                yelp-tools,
                pkg-config
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Homepage: https://github.com/LStranger/gnome-system-tools
 Vcs-Browser: https://github.com/LStranger/gnome-system-tools-debian
 Vcs-Git: https://github.com/LStranger/gnome-system-tools-debian.git

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,2 @@
+---
+Repository-Browse: https://gitlab.gnome.org/users/sign_in


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))
* Set upstream metadata fields: Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/5b783ae6-6017-4619-a3fc-80aecbba3aa6/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5b783ae6-6017-4619-a3fc-80aecbba3aa6/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5b783ae6-6017-4619-a3fc-80aecbba3aa6/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/5b783ae6-6017-4619-a3fc-80aecbba3aa6.